### PR TITLE
Use base entry factory formatting in rdbms connectors

### DIFF
--- a/rdbms2datacatalog/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/rdbms2datacatalog/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -16,9 +16,11 @@
 
 import pandas as pd
 from google.cloud import datacatalog_v1beta1
+from google.datacatalog_connectors.commons.prepare.base_entry_factory import \
+    BaseEntryFactory
 
 
-class DataCatalogEntryFactory:
+class DataCatalogEntryFactory(BaseEntryFactory):
     NO_VALUE_SPECIFIED = 'UNDEFINED'
     EMPTY_TOKEN = '?'
 
@@ -37,7 +39,7 @@ class DataCatalogEntryFactory:
          :return: entry_id, entry
         """
 
-        entry_id = table_container['name']
+        entry_id = self._format_id(table_container['name'])
         entry = datacatalog_v1beta1.types.Entry()
 
         entry.user_specified_type = self.__metadata_definition[
@@ -77,7 +79,8 @@ class DataCatalogEntryFactory:
          :return: entry_id, entry
         """
 
-        entry_id = '{}__{}'.format(table_container_name, table['name'])
+        entry_id = self._format_id('{}__{}'.format(table_container_name,
+                                                   table['name']))
 
         entry = datacatalog_v1beta1.types.Entry()
 
@@ -85,7 +88,7 @@ class DataCatalogEntryFactory:
             'type']
         entry.user_specified_system = self.__entry_group_id
 
-        entry.display_name = table['name']
+        entry.display_name = self._format_display_name(table['name'])
 
         entry.name = datacatalog_v1beta1.DataCatalogClient.entry_path(
             self.__project_id, self.__location_id, self.__entry_group_id,

--- a/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
+++ b/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
@@ -187,7 +187,7 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
 
             for table in tables:
                 table_entry = table.entry
-                self.assertEqual('CO__CUSTOMERS', table.entry_id)
+                self.assertEqual('CO_CUSTOMERS', table.entry_id)
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('oracle', table_entry.user_specified_system)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->
**- Motivation**
RDBMS allow special characters in table/column names which are illegal in data catalog.
The ids have to be max 64 chars long but are composed of two names which both can be up to 64 chars long, so they need to be trimmed.

**- What I did**
Start using base entry factory formatting method to format rdbms entries
**- How I did it**
Subclassed base entry factory and used the `_format_id` and `_format_display_name` methods.
**- How to verify it**
Ingest db with tables/columns with illegal character and/or length names.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use base entry factory formatting in rdbms connectors.

