### PR TITLE
Use id formatting everywhere where applicable, test for silly cases

### DIFF
--- a/rdbms2datacatalog/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/rdbms2datacatalog/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -46,7 +46,7 @@ class DataCatalogEntryFactory(BaseEntryFactory):
             'table_container_def']['type']
         entry.user_specified_system = self.__entry_group_id
 
-        entry.display_name = table_container['name']
+        entry.display_name = self._format_display_name(table_container['name'])
 
         create_time, update_time = \
             DataCatalogEntryFactory.__convert_source_system_timestamp_fields(
@@ -66,8 +66,8 @@ class DataCatalogEntryFactory(BaseEntryFactory):
             self.__project_id, self.__location_id, self.__entry_group_id,
             entry_id)
 
-        entry.linked_resource = '//{}//{}'.format(
-            self.__metadata_host_server, table_container['name'].strip())
+        entry.linked_resource = '//{}//{}'.format(self.__metadata_host_server,
+                                                  entry_id)
 
         return entry_id, entry
 
@@ -100,8 +100,8 @@ class DataCatalogEntryFactory(BaseEntryFactory):
 
         entry.description = desc
 
-        entry.linked_resource = '//{}//{}'.format(self.__metadata_host_server,
-                                                  table['name'])
+        entry.linked_resource = '//{}//{}'.format(
+            self.__metadata_host_server, self._format_id(table['name']))
 
         create_time, update_time = \
             DataCatalogEntryFactory.__convert_source_system_timestamp_fields(
@@ -118,7 +118,7 @@ class DataCatalogEntryFactory(BaseEntryFactory):
                 desc = ''
             columns.append(
                 datacatalog_v1beta1.types.ColumnSchema(
-                    column=column['name'],
+                    column=self._format_id(column['name']),
                     description=desc,
                     type=DataCatalogEntryFactory.__format_entry_column_type(
                         column['type']),

--- a/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
+++ b/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
@@ -216,6 +216,59 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 self.assertEqual('What this customer is called',
                                  third_column.description)
 
+    def test_should_be_converted_to_dc_entries_illegal_characters(  # noqa
+            self, entry_path):
+        entry_path.return_value = \
+            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+        entry_factory = self.__assembled_entry_factory
+
+        schema_metadata = utils.Utils.convert_json_to_object(
+            self.__MODULE_PATH, 'metadata_illegal_names.json')
+
+        prepared_entries = \
+            entry_factory. \
+            make_entries_from_table_container_metadata(
+                schema_metadata)
+
+        tables = prepared_entries[0][1]
+        self.assertEqual(len(tables), 1)
+
+        for schema, tables in prepared_entries:
+            schema_entry = schema.entry
+            self.assertEqual(
+                'CO_very_looooooooooooooooooooooooooooooooooooooooooooooooong',
+                schema.entry_id)
+            self.assertEqual('schema', schema_entry.user_specified_type)
+            self.assertEqual(AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
+                             schema_entry.name)
+            self.assertEqual('', schema_entry.description)
+            self.assertEqual(
+                '//metadata_host//CO_very_looooooooooooooooooooooooooooooooooo'
+                'oooooooooooooong', schema_entry.linked_resource)
+            self.assertEqual('oracle', schema_entry.user_specified_system)
+
+            for table in tables:
+                print(table.entry_id)
+                table_entry = table.entry
+                self.assertEqual(
+                    'CO_very_looooooooooooooooooooooooooooooooooooooooooooooo'
+                    'oong_CUS', table.entry_id)
+                # Assert specific fields for table
+                self.assertEqual('table', table_entry.user_specified_type)
+                self.assertEqual('oracle', table_entry.user_specified_system)
+                self.assertEqual(
+                    AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
+                    table_entry.name)
+                self.assertEqual(
+                    '//metadata_host//CUSTOMERS_very_loooooooooooooooooooooooo'
+                    'oooooooooooooooooong', table_entry.linked_resource)
+                self.assertGreater(len(table_entry.schema.columns), 0)
+                first_column = table_entry.schema.columns[0]
+                self.assertEqual('NUMBER', first_column.type)
+                self.assertEqual('CUSTOMER_ID_2', first_column.column)
+                self.assertEqual('Auto-incrementing primary key',
+                                 first_column.description)
+
     def test_schema_no_tables_should_be_converted_to_dc_entries(  # noqa
             self, entry_path):
         entry_path.return_value = \

--- a/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/test_data/metadata_illegal_names.json
+++ b/rdbms2datacatalog/tests/google/datacatalog_connectors/rdbms/test_data/metadata_illegal_names.json
@@ -1,0 +1,29 @@
+{
+    "schemas": [
+        {
+            "name": "CO_$/\\_very_looooooooooooooooooooooooooooooooooooooooooooooooong",
+            "create_time": "2019-11-19 00:00:00",
+            "tables": [
+                {
+                    "name": "CUSTOMERS_$/\\_very_loooooooooooooooooooooooooooooooooooooooooong",
+                    "desc": "Details of the people placing orders",
+                    "create_time": "2019-11-19 00:00:00",
+                    "update_time": "2019-11-19 00:00:00",
+                    "num_rows": 392.0,
+                    "columns": [
+                        {
+                            "name": "CUSTOMER_ID/2",
+                            "type": "NUMBER",
+                            "type_ext": "NUMBER",
+                            "desc": "Auto-incrementing primary key",
+                            "length": "22",
+                            "data_precision": NaN,
+                            "data_scale": 0.0,
+                            "nullable": "N"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Initial version missed a few more places where invalid characters could be used, this fixes that and adds a test with silly names to catch all these.