### PR TITLE
Use both schema and table name in pg metadata query to avoid duplicat…

### DIFF
--- a/postgresql2datacatalog/src/google/datacatalog_connectors/postgresql/config/metadata_query.sql
+++ b/postgresql2datacatalog/src/google/datacatalog_connectors/postgresql/config/metadata_query.sql
@@ -24,7 +24,7 @@ SELECT  t.table_schema as schema_name,
         c.numeric_precision as column_numeric_precision
     FROM information_schema.tables t
         JOIN  information_schema.columns c
-        on c.table_name = t.table_name
+        on c.table_name = t.table_name and c.table_schema = t.table_schema
     WHERE t.table_schema NOT IN
         ('pg_catalog', 'information_schema',
             'pg_toast', 'gp_toolkit', 'pg_internal')


### PR DESCRIPTION
…e results

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Fix pg metadata query.

**- How I did it**
By using schema to match results as well

**- How to verify it**
Ingest metadata from a pg db with 2 different schemas containing tables with same name, or even with same columns.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use both schema and table name in pg metadata query to avoid duplicates.
