### PR TITLE
Support PG user defined types

### DIFF
--- a/postgresql2datacatalog/src/google/datacatalog_connectors/postgresql/config/metadata_query.sql
+++ b/postgresql2datacatalog/src/google/datacatalog_connectors/postgresql/config/metadata_query.sql
@@ -14,18 +14,34 @@
 * limitations under the License.
 */
 
-SELECT  t.table_schema as schema_name,
-        t.table_name, t.table_type,
-        c.column_name,
-        c.column_default as column_default_value,
-        c.is_nullable as column_nullable,
-        c.data_type as column_type,
-        c.character_maximum_length as column_char_length,
-        c.numeric_precision as column_numeric_precision
+WITH enums AS (
+    select
+       n.nspname as enum_schema,
+       t.typname as enum_name,
+       STRING_AGG(e.enumlabel, ', ') as enum_values
+    FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+    GROUP BY n.nspname, t.typname
+)
+SELECT t.table_schema as schema_name,
+       t.table_name, t.table_type,
+       c.column_name,
+       c.column_default as column_default_value,
+       c.is_nullable as column_nullable,
+       CASE
+           WHEN e.enum_values is not null THEN 'enum'
+           WHEN e.enum_values is null AND c.data_type = 'USER-DEFINED' THEN 'user_defined'
+           ELSE c.data_type
+       END as column_type,
+       c.character_maximum_length as column_char_length,
+       c.numeric_precision as column_numeric_precision,
+       e.enum_values as column_enum_values
     FROM information_schema.tables t
         JOIN  information_schema.columns c
         on c.table_name = t.table_name and c.table_schema = t.table_schema
+        LEFT JOIN enums e on e.enum_schema = c.udt_schema and e.enum_name = c.udt_name
     WHERE t.table_schema NOT IN
         ('pg_catalog', 'information_schema',
-            'pg_toast', 'gp_toolkit', 'pg_internal')
+         'pg_toast', 'gp_toolkit', 'pg_internal')
     ORDER BY t.table_name, c.column_name;


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added support for pg user defined types - pg uses "USER-DEFINED" for them, this is not acceptable by catalog.
**- How I did it**
By pulling more info on user defined enums, using that and converting the ambiguous system "USER-DEFINED" name into something a bit more usable
**- How to verify it**
Ingest any db with user defined types in it
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support PG user defined types
