### PR TITLE
Add CLI parameter entry group id

### DIFF
--- a/google-datacatalog-greenplum-connector/src/google/datacatalog_connectors/greenplum/datacatalog_cli.py
+++ b/google-datacatalog-greenplum-connector/src/google/datacatalog_connectors/greenplum/datacatalog_cli.py
@@ -35,7 +35,7 @@ class Greenplum2DatacatalogCli(datacatalog_cli.PostgreSQL2DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'greenplum'
+        return args.datacatalog_entry_group_id or 'greenplum'
 
     def _parse_args(self, argv):
         parser = argparse.ArgumentParser(
@@ -49,6 +49,9 @@ class Greenplum2DatacatalogCli(datacatalog_cli.PostgreSQL2DatacatalogCli):
             '--datacatalog-location-id',
             help='Location ID to be used for your Google Cloud Datacatalog',
             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument(
             '--greenplum-host',
             help='Your Greenplum server host, this is required even'

--- a/google-datacatalog-greenplum-connector/tests/google/datacatalog_connectors/greenplum/datacatalog_cli_test.py
+++ b/google-datacatalog-greenplum-connector/tests/google/datacatalog_connectors/greenplum/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(unittest.TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.greenplum_host = 'host'
         mocked_parse_args.greenplum_user = 'user'
         mocked_parse_args.greenplum_pass = 'pass'
@@ -57,7 +58,8 @@ class DatacatalogCLITestCase(unittest.TestCase):
                     or '--greenplum-pass' in command \
                     or '--greenplum-database' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-mysql-connector/src/google/datacatalog_connectors/mysql_/datacatalog_cli.py
+++ b/google-datacatalog-mysql-connector/src/google/datacatalog_connectors/mysql_/datacatalog_cli.py
@@ -41,7 +41,7 @@ class MySQL2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'mysql'
+        return args.datacatalog_entry_group_id or 'mysql'
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -63,6 +63,9 @@ class MySQL2DatacatalogCli(datacatalog_cli.DatacatalogCli):
             '--datacatalog-location-id',
             help='Location ID to be used for your Google Cloud Datacatalog',
             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument(
             '--mysql-host',
             help='Your mysql server host, this is required even'

--- a/google-datacatalog-mysql-connector/tests/google/datacatalog_connectors/mysql_/datacatalog_cli_test.py
+++ b/google-datacatalog-mysql-connector/tests/google/datacatalog_connectors/mysql_/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(unittest.TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.mysql_host = 'host'
         mocked_parse_args.mysql_user = 'user'
         mocked_parse_args.mysql_pass = 'pass'
@@ -57,7 +58,8 @@ class DatacatalogCLITestCase(unittest.TestCase):
                     or '--mysql-pass' in command \
                     or '--mysql-database' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-oracle-connector/src/google/datacatalog_connectors/oracle/datacatalog_cli.py
+++ b/google-datacatalog-oracle-connector/src/google/datacatalog_connectors/oracle/datacatalog_cli.py
@@ -41,7 +41,7 @@ class Oracle2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'oracle'
+        return args.datacatalog_entry_group_id or 'oracle'
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -63,6 +63,9 @@ class Oracle2DatacatalogCli(datacatalog_cli.DatacatalogCli):
                             help='Location ID to be used for your'
                             ' Google Cloud Datacatalog',
                             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument('--oracle-host',
                             help='Your Oracle server host,'
                             ' this is required even'

--- a/google-datacatalog-oracle-connector/tests/google/datacatalog_connectors/oracle/datacatalog_cli_test.py
+++ b/google-datacatalog-oracle-connector/tests/google/datacatalog_connectors/oracle/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.oracle_host = 'host'
         mocked_parse_args.oracle_port = 1521
         mocked_parse_args.oracle_user = 'pass'
@@ -59,7 +60,8 @@ class DatacatalogCLITestCase(TestCase):
                     or '--oracle-pass' in command \
                     or '--oracle-db-service' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/datacatalog_cli.py
+++ b/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/datacatalog_cli.py
@@ -41,7 +41,7 @@ class PostgreSQL2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'postgresql'
+        return args.datacatalog_entry_group_id or 'postgresql'
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -63,6 +63,9 @@ class PostgreSQL2DatacatalogCli(datacatalog_cli.DatacatalogCli):
             '--datacatalog-location-id',
             help='Location ID to be used for your Google Cloud Datacatalog',
             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument(
             '--postgresql-host',
             help='Your postgresql server host, this is required even'

--- a/google-datacatalog-postgresql-connector/tests/google/datacatalog_connectors/postgresql/datacatalog_cli_test.py
+++ b/google-datacatalog-postgresql-connector/tests/google/datacatalog_connectors/postgresql/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(unittest.TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.postgresql_host = 'host'
         mocked_parse_args.postgresql_user = 'user'
         mocked_parse_args.postgresql_pass = 'pass'
@@ -57,7 +58,8 @@ class DatacatalogCLITestCase(unittest.TestCase):
                     or '--postgresql-pass' in command \
                     or '--postgresql-database' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-rdbmscsv-connector/src/google/datacatalog_connectors/rdbmscsv/datacatalog_cli.py
+++ b/google-datacatalog-rdbmscsv-connector/src/google/datacatalog_connectors/rdbmscsv/datacatalog_cli.py
@@ -28,7 +28,7 @@ class RDBMSCSV2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         return args.rdbms_host
 
     def _get_entry_group_id(self, args):
-        return args.rdbms_type
+        return args.datacatalog_entry_group_id or args.rdbms_type
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -46,6 +46,9 @@ class RDBMSCSV2DatacatalogCli(datacatalog_cli.DatacatalogCli):
                             help='Location ID to be used for your'
                             ' Google Cloud Datacatalog',
                             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument('--rdbms-host',
                             help='Your RDBMS server host',
                             required=True)

--- a/google-datacatalog-rdbmscsv-connector/tests/google/datacatalog_connectors/rdbmscsv/datacatalog_cli_test.py
+++ b/google-datacatalog-rdbmscsv-connector/tests/google/datacatalog_connectors/rdbmscsv/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.rdbms_host = 'host'
         mocked_parse_args.rdbms_type = 'oracle'
         mocked_parse_args.raw_metadata_csv = 'csv'
@@ -51,7 +52,8 @@ class DatacatalogCLITestCase(TestCase):
             command = arg[0]
             # Verify args which should not contain the required attribute
             if '--service-account-path' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/datacatalog_cli.py
+++ b/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/datacatalog_cli.py
@@ -36,7 +36,7 @@ class Redshift2DatacatalogCli(datacatalog_cli.PostgreSQL2DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'redshift'
+        return args.datacatalog_entry_group_id or 'redshift'
 
     def _parse_args(self, argv):
         parser = argparse.ArgumentParser(
@@ -50,6 +50,9 @@ class Redshift2DatacatalogCli(datacatalog_cli.PostgreSQL2DatacatalogCli):
             '--datacatalog-location-id',
             help='Location ID to be used for your Google Cloud Datacatalog',
             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument(
             '--redshift-host',
             help='Your Redshift server host, this is required even'

--- a/google-datacatalog-redshift-connector/tests/google/datacatalog_connectors/redshift/datacatalog_cli_test.py
+++ b/google-datacatalog-redshift-connector/tests/google/datacatalog_connectors/redshift/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(unittest.TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.redshift_host = 'host'
         mocked_parse_args.redshift_port = 5555
         mocked_parse_args.redshift_user = 'user'
@@ -59,7 +60,8 @@ class DatacatalogCLITestCase(unittest.TestCase):
                     or '--redshift-database' in command \
                     or '--redshift-port' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-sqlserver-connector/src/google/datacatalog_connectors/sqlserver/datacatalog_cli.py
+++ b/google-datacatalog-sqlserver-connector/src/google/datacatalog_connectors/sqlserver/datacatalog_cli.py
@@ -40,7 +40,7 @@ class SQLServer2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'sqlserver'
+        return args.datacatalog_entry_group_id or 'sqlserver'
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -62,6 +62,9 @@ class SQLServer2DatacatalogCli(datacatalog_cli.DatacatalogCli):
             '--datacatalog-location-id',
             help='Location ID to be used for your Google Cloud Datacatalog',
             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument(
             '--sqlserver-host',
             help='Your sqlserver server host, this is required even'

--- a/google-datacatalog-sqlserver-connector/tests/google/datacatalog_connectors/sqlserver/datacatalog_cli_test.py
+++ b/google-datacatalog-sqlserver-connector/tests/google/datacatalog_connectors/sqlserver/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(unittest.TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.sqlserver_host = 'host'
         mocked_parse_args.sqlserver_user = 'user'
         mocked_parse_args.sqlserver_pass = 'pass'
@@ -57,7 +58,8 @@ class DatacatalogCLITestCase(unittest.TestCase):
                     or '--sqlserver-pass' in command \
                     or '--sqlserver-database' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-teradata-connector/src/google/datacatalog_connectors/teradata/datacatalog_cli.py
+++ b/google-datacatalog-teradata-connector/src/google/datacatalog_connectors/teradata/datacatalog_cli.py
@@ -39,7 +39,7 @@ class Teradata2DatacatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'teradata'
+        return args.datacatalog_entry_group_id or 'teradata'
 
     def _get_metadata_definition_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -61,6 +61,9 @@ class Teradata2DatacatalogCli(datacatalog_cli.DatacatalogCli):
                             help='Location ID to be used for your'
                             ' Google Cloud Datacatalog',
                             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument('--teradata-host',
                             help='Your Teradata server host,'
                             ' this is required even'

--- a/google-datacatalog-teradata-connector/tests/google/datacatalog_connectors/teradata/datacatalog_cli_test.py
+++ b/google-datacatalog-teradata-connector/tests/google/datacatalog_connectors/teradata/datacatalog_cli_test.py
@@ -37,6 +37,7 @@ class DatacatalogCLITestCase(TestCase):
 
         mocked_parse_args.datacatalog_project_id = 'test_project_id'
         mocked_parse_args.datacatalog_location_id = 'location_id'
+        mocked_parse_args.datacatalog_entry_group_id = 'entry_group_id'
         mocked_parse_args.teradata_host = 'host'
         mocked_parse_args.hive_metastore_db_user = 'user'
         mocked_parse_args.teradata_user = 'pass'
@@ -56,7 +57,8 @@ class DatacatalogCLITestCase(TestCase):
                     or '--teradata-user' in command \
                     or '--teradata-pass' in command \
                     or '--raw-metadata-csv' in command \
-                    or '--enable-monitoring' in command:
+                    or '--enable-monitoring' in command \
+                    or '--datacatalog-entry-group-id' in command:
                 params = call_arg[1]
                 required = params.get('required')
                 self.assertFalse(required)

--- a/google-datacatalog-vertica-connector/src/google/datacatalog_connectors/vertica/vertica2datacatalog_cli.py
+++ b/google-datacatalog-vertica-connector/src/google/datacatalog_connectors/vertica/vertica2datacatalog_cli.py
@@ -36,7 +36,7 @@ class Vertica2DataCatalogCli(datacatalog_cli.DatacatalogCli):
         }
 
     def _get_entry_group_id(self, args):
-        return 'vertica'
+        return args.datacatalog_entry_group_id or 'vertica'
 
     def _get_metadata_scraper(self):
         return scrape.MetadataScraper
@@ -68,6 +68,9 @@ class Vertica2DataCatalogCli(datacatalog_cli.DatacatalogCli):
         parser.add_argument('--datacatalog-location-id',
                             help='Google Cloud Location ID',
                             required=True)
+        parser.add_argument('--datacatalog-entry-group-id',
+                            help='Entry group ID to be used for your Google '
+                            'Cloud Datacatalog')
         parser.add_argument('--service-account-path',
                             help='Local Service Account path (can be supplied'
                             ' as the GOOGLE_APPLICATION_CREDENTIALS'

--- a/google-datacatalog-vertica-connector/tests/google/datacatalog_connectors/vertica/vertica2datacatalog_cli_test.py
+++ b/google-datacatalog-vertica-connector/tests/google/datacatalog_connectors/vertica/vertica2datacatalog_cli_test.py
@@ -48,8 +48,15 @@ class Vertica2DataCatalogCliTest(unittest.TestCase):
         self.assertEqual(expected_connection_args,
                          self.__cli._get_connection_args(args))
 
-    def test_get_entry_group_id_should_return_vertica(self):
-        self.assertEqual('vertica', self.__cli._get_entry_group_id({}))
+    def test_get_entry_group_id_should_return_value(self):
+        args = DictWithAttributeAccess()
+        args['datacatalog_entry_group_id'] = 'entry-group'
+        self.assertEqual('entry-group', self.__cli._get_entry_group_id(args))
+
+    def test_get_entry_group_id_should_return_vertica_when_missing(self):
+        args = DictWithAttributeAccess()
+        args['datacatalog_entry_group_id'] = None
+        self.assertEqual('vertica', self.__cli._get_entry_group_id(args))
 
     def test_get_metadata_scraper_should_return_vertica_scraper(self):
         self.assertEqual(scrape.MetadataScraper,


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
I added optional parameter `--datacatalog-entry-group-id`. Resolves #14 
**- How I did it**
When it is provided it will be used as entry group name othervise previous hard-coded name is used.
**- How to verify it**
Run connector with and without parameter `--datacatalog-entry-group-id` specified.
**- Description for the changelog**
Added CLI parameter datacatalog-entry-group-id
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

