### PR TITLE
FIX redshift does not support pg_enum table

### DIFF
--- a/google-datacatalog-redshift-connector/MANIFEST.in
+++ b/google-datacatalog-redshift-connector/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src *.json *.sql

--- a/google-datacatalog-redshift-connector/README.md
+++ b/google-datacatalog-redshift-connector/README.md
@@ -139,8 +139,8 @@ google-datacatalog-redshift-connector \
 --datacatalog-location-id=$REDSHIFT2DC_DATACATALOG_LOCATION_ID \
 --redshift-host=$REDSHIFT2DC_SERVER \
 --redshift-user=$REDSHIFT2DC_USERNAME \
---redshift-pass=$REDSHIFT_PASSWORD \
---redshift-database=$REDSHIFT_DATABASE  \
+--redshift-pass=$REDSHIFT2DC_PASSWORD \
+--redshift-database=$REDSHIFT2DC_DATABASE  \
 --raw-metadata-csv=$REDSHIFT2DC_RAW_METADATA_CSV      
 ```
 
@@ -153,8 +153,8 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data redshift2datacatalo
 --datacatalog-location-id=$REDSHIFT2DC_DATACATALOG_LOCATION_ID \
 --redshift-host=$REDSHIFT2DC_SERVER \
 --redshift-user=$REDSHIFT2DC_USERNAME \
---redshift-pass=$REDSHIFT_PASSWORD \
---redshift-database=$REDSHIFT_DATABASE  \
+--redshift-pass=$REDSHIFT2DC_PASSWORD \
+--redshift-database=$REDSHIFT2DC_DATABASE  \
 --raw-metadata-csv=$REDSHIFT2DC_RAW_METADATA_CSV       
 ```
 

--- a/google-datacatalog-redshift-connector/setup.py
+++ b/google-datacatalog-redshift-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-redshift-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Library for ingesting Redshift metadata into Google Cloud Data Catalog',
     platforms='Posix; MacOS X; Windows',

--- a/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/config/metadata_query.sql
+++ b/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/config/metadata_query.sql
@@ -1,0 +1,31 @@
+/*
+* Copyright 2020 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+SELECT  t.table_schema as schema_name,
+        t.table_name, t.table_type,
+        c.column_name,
+        c.column_default as column_default_value,
+        c.is_nullable as column_nullable,
+        c.data_type as column_type,
+        c.character_maximum_length as column_char_length,
+        c.numeric_precision as column_numeric_precision
+    FROM information_schema.tables t
+        JOIN  information_schema.columns c
+        on c.table_name = t.table_name and c.table_schema = t.table_schema
+    WHERE t.table_schema NOT IN
+        ('pg_catalog', 'information_schema',
+            'pg_toast', 'gp_toolkit', 'pg_internal')
+    ORDER BY t.table_name, c.column_name;

--- a/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/datacatalog_cli.py
+++ b/google-datacatalog-redshift-connector/src/google/datacatalog_connectors/redshift/datacatalog_cli.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import os
 import sys
 
 from google.datacatalog_connectors.postgresql import \
@@ -34,6 +35,10 @@ class Redshift2DatacatalogCli(datacatalog_cli.PostgreSQL2DatacatalogCli):
             'user': args.redshift_user,
             'pass': args.redshift_pass
         }
+
+    def _get_query_path(self, args):
+        return os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'config/metadata_query.sql')
 
     def _get_entry_group_id(self, args):
         return args.datacatalog_entry_group_id or 'redshift'


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Overrode PostgreSQL metadata query to not use **pg_enum** table, which is not supported on the current Redshift version.

**- How I did it**
Overrode PostgreSQL metadata query.

**- How to verify it**
Run Redshift connector against the default supported version.

**- Description for the changelog**
Overrode PostgreSQL metadata query to not use **pg_enum** table, which is not supported on the current Redshift version.

