### PR TITLE
REMOVE char that breaks pip install in windows

### DIFF
--- a/google-datacatalog-postgresql-connector/README.md
+++ b/google-datacatalog-postgresql-connector/README.md
@@ -7,7 +7,7 @@ Library for ingesting PostgreSQL metadata into Google Cloud Data Catalog.
 **Disclaimer: This is not an officially supported Google product.**
 
 <!--
-  ⚠️ DO NOT UPDATE THE TABLE OF CONTENTS MANUALLY ️️⚠️
+  DO NOT UPDATE THE TABLE OF CONTENTS MANUALLY
   run `npx markdown-toc -i README.md`.
 
   Please stick to 80-character line wraps as much as you can.


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Removed ⚠️ symbol from docs, since it is not needed.

**- How I did it**
Removed ⚠️ symbol from docs, since it is not needed.

**- How to verify it**
Install the package on Windows.

**- Description for the changelog**
As reported on #24, the ⚠️ symbol breaks the pip installation on Windows. So removed this symbol from docs, since it is not needed.

