### PR TITLE
UPDATE set fixed versions before datacatalog v2 client breaking change

### DIFF
--- a/google-datacatalog-greenplum-connector/setup.py
+++ b/google-datacatalog-greenplum-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-greenplum-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Library for ingesting Greenplum metadata into Google Cloud Data Catalog',
     platforms='Posix; MacOS X; Windows',
@@ -36,13 +36,13 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('google-datacatalog-postgresql-connector'),
+    install_requires=('google-datacatalog-postgresql-connector>=0.7.1,<0.8.0'),
     setup_requires=(
         'pytest-runner',
     ),
     tests_require=(
         'pytest-cov',
-        'google-datacatalog-connectors-commons-test'
+        'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'
     ),
     classifiers=(
         release_status,

--- a/google-datacatalog-mysql-connector/setup.py
+++ b/google-datacatalog-mysql-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-mysql-connector',
-    version='0.7.0',
+    version='0.7.1',
     author='Google LLC',
     description=
     'Library for ingesting MySQL metadata into Google Cloud Data Catalog',
@@ -37,9 +37,9 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('mysql-connector-python', 'google-datacatalog-rdbms-connector'),
+    install_requires=('mysql-connector-python', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-oracle-connector/setup.py
+++ b/google-datacatalog-oracle-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-oracle-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description=
     'Library for ingesting Oracle metadata into Google Cloud Data Catalog',
@@ -36,10 +36,10 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('cx_Oracle', 'google-datacatalog-rdbms-connector'),
+    install_requires=('cx_Oracle', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
     tests_require=('pytest-cov', 'mock==3.0.5', 'pytest',
-                   'google-datacatalog-connectors-commons-test'),
+                   'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=[
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-postgresql-connector/setup.py
+++ b/google-datacatalog-postgresql-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-postgresql-connector',
-    version='0.7.0',
+    version='0.7.1',
     author='Google LLC',
     description=
     'Library for ingesting Postgresql metadata into Google Cloud Data Catalog',
@@ -37,9 +37,9 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('psycopg2-binary', 'google-datacatalog-rdbms-connector'),
+    install_requires=('psycopg2-binary', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-rdbms-connector/setup.py
+++ b/google-datacatalog-rdbms-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-rdbms-connector',
-    version='0.8.1',
+    version='0.8.2',
     author='Google LLC',
     description=
     'Commons library for ingesting RDBMS metadata into Google Cloud Data Catalog',
@@ -32,10 +32,10 @@ setuptools.setup(
     package_dir={'': 'src'},
     include_package_data=True,
     install_requires=('pandas==0.24.2', 'gcsfs',
-                      'google-datacatalog-connectors-commons', 'pyYAML'),
+                      'google-datacatalog-connectors-commons>=0.5.2,<0.6.0', 'pyYAML'),
     setup_requires=('pytest-runner'),
     tests_require=('mock==3.0.5', 'pytest', 'pytest-cov',
-                   'google-datacatalog-connectors-commons-test'),
+                   'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=[
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-rdbmscsv-connector/setup.py
+++ b/google-datacatalog-rdbmscsv-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-rdbmscsv-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Library for ingesting RDBMS CSV metadata into Google Cloud Data Catalog',
     packages=setuptools.find_packages(where='./src'),
@@ -35,10 +35,10 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('google-datacatalog-rdbms-connector'),
+    install_requires=('google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner'),
     tests_require=('pytest-cov', 'mock==3.0.5', 'pytest',
-                   'google-datacatalog-connectors-commons-test'),
+                   'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=[
         release_status,
         "Programming Language :: Python :: 3.7",

--- a/google-datacatalog-redshift-connector/setup.py
+++ b/google-datacatalog-redshift-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-redshift-connector',
-    version='0.6.1',
+    version='0.6.2',
     author='Google LLC',
     description='Library for ingesting Redshift metadata into Google Cloud Data Catalog',
     platforms='Posix; MacOS X; Windows',
@@ -36,13 +36,13 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('google-datacatalog-postgresql-connector'),
+    install_requires=('google-datacatalog-postgresql-connector>=0.7.1,<0.8.0'),
     setup_requires=(
         'pytest-runner',
     ),
     tests_require=(
         'pytest-cov',
-        'google-datacatalog-connectors-commons-test'
+        'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'
     ),
     classifiers=(
         release_status,

--- a/google-datacatalog-sqlserver-connector/setup.py
+++ b/google-datacatalog-sqlserver-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-sqlserver-connector',
-    version='0.7.1',
+    version='0.7.2',
     author='Google LLC',
     description=
     'Library for ingesting SQLServer metadata into Google Cloud Data Catalog',
@@ -37,9 +37,9 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('pyodbc', 'google-datacatalog-rdbms-connector'),
+    install_requires=('pyodbc', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-teradata-connector/setup.py
+++ b/google-datacatalog-teradata-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-teradata-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description=
     'Library for ingesting Teradata metadata into Google Cloud Data Catalog',
@@ -37,9 +37,9 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('teradatasql', 'google-datacatalog-rdbms-connector'),
+    install_requires=('teradatasql', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=(
         release_status,
         'Programming Language :: Python :: 3.7',

--- a/google-datacatalog-vertica-connector/setup.py
+++ b/google-datacatalog-vertica-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-vertica-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Package for ingesting Vertica metadata'
                 ' into Google Cloud Data Catalog',
@@ -37,9 +37,9 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('vertica-python', 'google-datacatalog-rdbms-connector'),
+    install_requires=('vertica-python', 'google-datacatalog-rdbms-connector>=0.8.2,<0.9.0'),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test'),
+    tests_require=('pytest-cov', 'google-datacatalog-connectors-commons-test>=0.5.1,<0.6.0'),
     classifiers=[
         release_status,
         'Natural Language :: English',


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
UPDATE set fixed versions before datacatalog v2 client breaking change

**- How I did it**
Fixed dependencies versions on `setup.py`, so it's going to use versions before v2 client breaking change.

**- How to verify it**
Install rdbms connectors from PyPI

**- Description for the changelog**
UPDATE set fixed versions before datacatalog v2 client breaking change

