### PR TITLE
Add description field support for columns

### DIFF
--- a/google-datacatalog-postgresql-connector/README.md
+++ b/google-datacatalog-postgresql-connector/README.md
@@ -148,6 +148,7 @@ rows in each table. The table below shows what metadata is scraped by default, a
 | column_char_length           | Char length of values in a column           | Y                  | ---                          | 
 | column_numeric_precision     | Numeric precision of values in a column     | Y                  | ---                          | 
 | column_enum_values           | List of enum values for a column            | Y                  | ---                          | 
+| description                  | Description of a column (COMMENT statement) | Y                  | ---                          | 
 | ANALYZE statement            | Statement to refresh metadata information   | N                  | refresh_metadata_tables      |
 | table_rows                   | Number of rows in a table                   | N                  | sync_row_counts              |
 | base_metadata_query_filename | Overrides the base metadata query file name | N/A                | base_metadata_query_filename |

--- a/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/config/metadata_definition.json
+++ b/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/config/metadata_definition.json
@@ -29,6 +29,7 @@
         "key": "columns",
         "type": "column",
         "name": "column_name",
+        "desc": "description",
         "fields": [
             {
                 "source": "column_type",

--- a/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/config/metadata_with_description.sql
+++ b/google-datacatalog-postgresql-connector/src/google/datacatalog_connectors/postgresql/config/metadata_with_description.sql
@@ -1,0 +1,64 @@
+/*
+* Extract catalog information from pg_catalog.
+* Some Postgresql databases come without schema details in information schema
+* This query uses various tables from pg_catalog to build a catalog of columns with appropriate details:
+* - schema & table name
+* - table type is BASE TABLE
+* - column name
+* - column default value
+* - column nullable indicator
+* - column type with comma replaced with underscore for import as csv file
+* - description, as added with COMMENT SQL command
+* - table size in mb
+*
+* Freely inspired from SO: https://stackoverflow.com/questions/20194806/how-to-get-a-list-column-names-and-datatypes-of-a-table-in-postgresql
+*/
+
+SELECT t.schemaname as schema_name,
+       tablename as table_name, 'BASE TABLE' as table_type,
+       column_name,
+       CASE
+           WHEN has_default and column_type not in ('bigserial', 'serial') THEN default_value
+           ELSE null
+        END as column_default_value,
+       not(is_notnullable) as column_nullable,
+       pg_catalog.replace(column_type, ',', '_') as column_type, -- replace comma for CSV export
+       -- column_char_length, -- not supported in metadata definition
+       -- column_numeric_precision, -- not supported in metadata definition
+       -- column_enum_values, -- not supported in metadata definition
+       description,
+       table_size_mb
+    FROM pg_catalog.pg_tables as t
+        INNER JOIN (
+	        SELECT
+	            pg_class.relname as table_name,
+		        pg_namespace.nspname as schema_name,
+	            pg_attribute.attname as column_name,
+	            CASE pg_attribute.atttypid
+	    	        WHEN 'bigint'::regtype THEN 'bigserial'
+	    	        WHEN 'int'::regtype THEN 'serial'
+	    	        ELSE pg_catalog.format_type(pg_attribute.atttypid, pg_attribute.atttypmod)
+	            END as column_type,
+	            pg_attribute.attnotnull as is_notnullable,
+	            pg_attribute.atthasdef as has_default,
+	            pg_attrdef.adsrc as default_value,
+                CAST (pg_total_relation_size(pg_class.oid) AS FLOAT) / 1024 / 1024 as table_size_mb,
+	            pgd.description as description
+	        FROM
+	            pg_catalog.pg_attribute
+	            INNER JOIN
+	                pg_catalog.pg_class ON pg_class.oid = pg_attribute.attrelid
+	            INNER JOIN
+	                pg_catalog.pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+	            LEFT JOIN
+		            pg_catalog.pg_attrdef on pg_class.oid = pg_attrdef.adrelid and pg_attribute.attnum = pg_attrdef.adnum
+	            LEFT JOIN 
+		            pg_catalog.pg_description pgd on pgd.objoid = pg_attribute.attrelid and pgd.objsubid = pg_attribute.attnum
+	        WHERE
+	            pg_attribute.attnum > 0
+	            AND NOT pg_attribute.attisdropped
+        ) as c on c.schema_name = t.schemaname and c.table_name = t.tablename
+    WHERE t.schemaname NOT IN 
+        ('pg_catalog', 'information_schema',
+         'pg_toast', 'gp_toolkit', 'pg_internal')
+    ORDER BY schema_name, table_name, column_name

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
@@ -63,6 +63,7 @@ class MetadataNormalizer:
             ...            'key': 'columns',
             ...            'type': 'column',
             ...            'name': 'column_name',
+            ...            'desc': 'description',
             ...            'fields': [
             ...                {
             ...                    'source': 'data_length',
@@ -195,6 +196,11 @@ class MetadataNormalizer:
         fields = column_def['fields']
 
         normalized_dict = {'name': name}
+
+        if column_def['desc'] in column_metadata.columns:
+            value = cls._extract_value_from_first_row(column_metadata, column_def['desc']) 
+            if not pd.isna(value):
+                normalized_dict['desc'] = value
 
         normalized_dict.update(cls._normalize_fields(fields, column_metadata))
 

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
@@ -197,7 +197,7 @@ class MetadataNormalizer:
 
         normalized_dict = {'name': name}
 
-        if column_def['desc'] in column_metadata.columns:
+        if 'desc' in column_def and column_def['desc'] in column_metadata.columns:
             value = cls._extract_value_from_first_row(column_metadata,
                                                       column_def['desc'])
             if not pd.isna(value):

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
@@ -198,7 +198,8 @@ class MetadataNormalizer:
         normalized_dict = {'name': name}
 
         if column_def['desc'] in column_metadata.columns:
-            value = cls._extract_value_from_first_row(column_metadata, column_def['desc']) 
+            value = cls._extract_value_from_first_row(column_metadata,
+                                                      column_def['desc']) 
             if not pd.isna(value):
                 normalized_dict['desc'] = value
 

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
@@ -197,7 +197,8 @@ class MetadataNormalizer:
 
         normalized_dict = {'name': name}
 
-        if 'desc' in column_def and column_def['desc'] in column_metadata.columns:
+        if 'desc' in column_def \
+            and column_def['desc'] in column_metadata.columns:
             value = cls._extract_value_from_first_row(column_metadata,
                                                       column_def['desc'])
             if not pd.isna(value):

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/scrape/metadata_normalizer.py
@@ -199,7 +199,7 @@ class MetadataNormalizer:
 
         if column_def['desc'] in column_metadata.columns:
             value = cls._extract_value_from_first_row(column_metadata,
-                                                      column_def['desc']) 
+                                                      column_def['desc'])
             if not pd.isna(value):
                 normalized_dict['desc'] = value
 


### PR DESCRIPTION
**- What I did**

Add the ability to provide a description of columns.
Descriptions can be collected through a metadata SQL query that reads comments from Postgresql catalog.
Alternatively descriptions can be added to a metadata CSV file.
Column tag description fields are upsert with other fields.

**- How I did it**

Check if a description field is available from metadata and populate tag 'desc' field.

**- How to verify it**

Description fields appear in Data Catalog once upserted.

_Question: shall I adapt test cases to include a description field?_

**- Description for the changelog**

Add support to upsert column description field.