### PR TITLE
FIX issue when MYSQL would return a byte object instead of str

### DIFF
--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -172,13 +172,13 @@ class DataCatalogEntryFactory(BaseEntryFactory):
     def __format_entry_column_type(source_name):
         if isinstance(source_name, bytes):
             # Use UTF-8 default encoding observed in MySQL, other RDBMS'
-            # don't seem to have scenarios where the column type is returned as bytes
-            # if we observe other issues like this in the other RDBMS connectors
-            # we should set the encode type as a config that each RDBMS connector
-            # has to set up, and could be exposed as a CLI arg, so users can easily
-            # change that.
+            # don't seem to have scenarios where the column type is
+            # returned as bytes if we observe other issues like this in the
+            # other RDBMS connectors we should set the encode type as a config
+            # that each RDBMS connector has to set up, and could be exposed
+            # as a CLI arg, so users can easily change that.
             source_name = source_name.decode("utf-8")
-            
+
         formatted_name = source_name.replace('&', '_')
         formatted_name = formatted_name.replace(':', '_')
         formatted_name = formatted_name.replace('/', '_')

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -171,14 +171,16 @@ class DataCatalogEntryFactory(BaseEntryFactory):
     @staticmethod
     def __format_entry_column_type(source_name):
         if isinstance(source_name, bytes):
-            # Use UTF-8 default encoding observed in MySQL, other RDBMS'
-            # don't seem to have scenarios where the column type is
-            # returned as bytes if we observe other issues like this in the
-            # other RDBMS connectors we should set the encode type as a config
-            # that each RDBMS connector has to set up, and could be exposed
-            # as a CLI arg, so users can easily change that.
-            # There is also the option to scrape that config directly
-            # from the DB.
+            # We've noticed some MySQL instances use bytes-like objects
+            # instead of `str` to specify the column types. We are using UTF-8
+            # to decode such objects when it happens because UTF-8 is the
+            # default character set for MySQL 8.0 onwards.
+            #
+            # We didn't notice similar behavior with other RDBMS but, if so,
+            # we should handle encoding as a configuration option that each
+            # RDBMS connector would have to set up. It might be exposed as a
+            # CLI arg, so users could easily change that. There is also the
+            # option to  scrape that config directly from the DB.
             source_name = source_name.decode("utf-8")
 
         formatted_name = source_name.replace('&', '_')

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -177,6 +177,8 @@ class DataCatalogEntryFactory(BaseEntryFactory):
             # other RDBMS connectors we should set the encode type as a config
             # that each RDBMS connector has to set up, and could be exposed
             # as a CLI arg, so users can easily change that.
+            # There is also the option to scrape that config directly
+            # from the DB.
             source_name = source_name.decode("utf-8")
 
         formatted_name = source_name.replace('&', '_')

--- a/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-rdbms-connector/src/google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py
@@ -170,6 +170,15 @@ class DataCatalogEntryFactory(BaseEntryFactory):
 
     @staticmethod
     def __format_entry_column_type(source_name):
+        if isinstance(source_name, bytes):
+            # Use UTF-8 default encoding observed in MySQL, other RDBMS'
+            # don't seem to have scenarios where the column type is returned as bytes
+            # if we observe other issues like this in the other RDBMS connectors
+            # we should set the encode type as a config that each RDBMS connector
+            # has to set up, and could be exposed as a CLI arg, so users can easily
+            # change that.
+            source_name = source_name.decode("utf-8")
+            
         formatted_name = source_name.replace('&', '_')
         formatted_name = formatted_name.replace(':', '_')
         formatted_name = formatted_name.replace('/', '_')

--- a/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
@@ -282,9 +282,12 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
             self.__MODULE_PATH, 'metadata_column_type_as_bytes.json')
 
         # we can't set the bytes value directly in the JSON file
-        # so for this test case, we just convert the str value to the bytes representation.
-        varchar_type = schema_metadata['schemas'][0]['tables'][0]['columns'][0]['type']
-        schema_metadata['schemas'][0]['tables'][0]['columns'][0]['type'] = varchar_type.encode("utf-8")
+        # so for this test case, we just convert the str value
+        # to the bytes representation.
+        varchar_type = schema_metadata['schemas'][0]['tables'][0]['columns'][
+            0]['type']
+        schema_metadata['schemas'][0]['tables'][0]['columns'][0][
+            'type'] = varchar_type.encode("utf-8")
 
         prepared_entries = \
             entry_factory. \

--- a/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
@@ -272,6 +272,67 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
                 self.assertEqual('Auto-incrementing primary key',
                                  first_column.description)
 
+    def test_should_be_converted_to_dc_entries_column_type_as_bytes(  # noqa
+            self, entry_path):
+        entry_path.return_value = \
+            AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH
+        entry_factory = self.__assembled_entry_factory
+
+        schema_metadata = utils.Utils.convert_json_to_object(
+            self.__MODULE_PATH, 'metadata_column_type_as_bytes.json')
+
+        # we can't set the bytes value directly in the JSON file
+        # so for this test case, we just convert the str value to the bytes representation.
+        varchar_type = schema_metadata['schemas'][0]['tables'][0]['columns'][0]['type']
+        schema_metadata['schemas'][0]['tables'][0]['columns'][0]['type'] = varchar_type.encode("utf-8")
+
+        prepared_entries = \
+            entry_factory. \
+            make_entries(schema_metadata)
+
+        tables = prepared_entries[0][1]
+        self.assertEqual(len(tables), 1)
+
+        for schema, tables in prepared_entries:
+            schema_entry = schema.entry
+            self.assertEqual(
+                'CO_very_looooooooooooooooooooooooooooooooooooooooooooooooong',
+                schema.entry_id)
+            self.assertEqual('schema', schema_entry.user_specified_type)
+            self.assertEqual(AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
+                             schema_entry.name)
+            self.assertEqual('', schema_entry.description)
+            self.assertEqual(
+                'metadata_host/'
+                'CO_very_looooooooooooooooooooooooooooooooooooooooooooooooong',
+                schema_entry.linked_resource)
+            self.assertEqual('oracle', schema_entry.user_specified_system)
+
+            for table in tables:
+                print(table.entry_id)
+                table_entry = table.entry
+                self.assertEqual(
+                    'CO_very_looooooooooooooooooooooooooooooooooooooooooooooo'
+                    'oong_CUS', table.entry_id)
+                # Assert specific fields for table
+                self.assertEqual('table', table_entry.user_specified_type)
+                self.assertEqual('oracle', table_entry.user_specified_system)
+                self.assertEqual(
+                    AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
+                    table_entry.name)
+                self.assertEqual(
+                    'metadata_host/CO_$/'
+                    '_very_loooooooooooooooooooooooooo'
+                    'ooooooooooooooooooooooong'
+                    '/CUSTOMERS_very_loooooooooooooooooo'
+                    'oooooooooooooooooooooooong', table_entry.linked_resource)
+                self.assertGreater(len(table_entry.schema.columns), 0)
+                first_column = table_entry.schema.columns[0]
+                self.assertEqual('varchar', first_column.type)
+                self.assertEqual('CUSTOMER_ID_2', first_column.column)
+                self.assertEqual('Auto-incrementing primary key',
+                                 first_column.description)
+
     def test_schema_no_tables_should_be_converted_to_dc_entries(  # noqa
             self, entry_path):
         entry_path.return_value = \

--- a/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/prepare/assembled_entry_factory_test.py
@@ -298,37 +298,21 @@ class AssembledEntryFactoryTestCase(unittest.TestCase):
 
         for schema, tables in prepared_entries:
             schema_entry = schema.entry
-            self.assertEqual(
-                'CO_very_looooooooooooooooooooooooooooooooooooooooooooooooong',
-                schema.entry_id)
             self.assertEqual('schema', schema_entry.user_specified_type)
             self.assertEqual(AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
                              schema_entry.name)
             self.assertEqual('', schema_entry.description)
-            self.assertEqual(
-                'metadata_host/'
-                'CO_very_looooooooooooooooooooooooooooooooooooooooooooooooong',
-                schema_entry.linked_resource)
             self.assertEqual('oracle', schema_entry.user_specified_system)
 
             for table in tables:
                 print(table.entry_id)
                 table_entry = table.entry
-                self.assertEqual(
-                    'CO_very_looooooooooooooooooooooooooooooooooooooooooooooo'
-                    'oong_CUS', table.entry_id)
                 # Assert specific fields for table
                 self.assertEqual('table', table_entry.user_specified_type)
                 self.assertEqual('oracle', table_entry.user_specified_system)
                 self.assertEqual(
                     AssembledEntryFactoryTestCase.__MOCKED_ENTRY_PATH,
                     table_entry.name)
-                self.assertEqual(
-                    'metadata_host/CO_$/'
-                    '_very_loooooooooooooooooooooooooo'
-                    'ooooooooooooooooooooooong'
-                    '/CUSTOMERS_very_loooooooooooooooooo'
-                    'oooooooooooooooooooooooong', table_entry.linked_resource)
                 self.assertGreater(len(table_entry.schema.columns), 0)
                 first_column = table_entry.schema.columns[0]
                 self.assertEqual('varchar', first_column.type)

--- a/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/test_data/metadata_column_type_as_bytes.json
+++ b/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/test_data/metadata_column_type_as_bytes.json
@@ -1,11 +1,11 @@
 {
     "schemas": [
         {
-            "name": "CO_$/_very_looooooooooooooooooooooooooooooooooooooooooooooooong",
+            "name": "CO",
             "create_time": "2019-11-19 00:00:00",
             "tables": [
                 {
-                    "name": "CUSTOMERS_$/_very_loooooooooooooooooooooooooooooooooooooooooong",
+                    "name": "CUSTOMERS",
                     "desc": "Details of the people placing orders",
                     "create_time": "2019-11-19 00:00:00",
                     "update_time": "2019-11-19 00:00:00",

--- a/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/test_data/metadata_column_type_as_bytes.json
+++ b/google-datacatalog-rdbms-connector/tests/google/datacatalog_connectors/rdbms/test_data/metadata_column_type_as_bytes.json
@@ -1,0 +1,29 @@
+{
+    "schemas": [
+        {
+            "name": "CO_$/_very_looooooooooooooooooooooooooooooooooooooooooooooooong",
+            "create_time": "2019-11-19 00:00:00",
+            "tables": [
+                {
+                    "name": "CUSTOMERS_$/_very_loooooooooooooooooooooooooooooooooooooooooong",
+                    "desc": "Details of the people placing orders",
+                    "create_time": "2019-11-19 00:00:00",
+                    "update_time": "2019-11-19 00:00:00",
+                    "num_rows": 392.0,
+                    "columns": [
+                        {
+                            "name": "CUSTOMER_ID/2",
+                            "type": "varchar",
+                            "type_ext": "NUMBER",
+                            "desc": "Auto-incrementing primary key",
+                            "length": "22",
+                            "data_precision": NaN,
+                            "data_scale": 0.0,
+                            "nullable": "N"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
- Fixed error at prepare stage for MySQL connector.

```
google/datacatalog_connectors/rdbms/prepare/datacatalog_entry_factory.py", line 173, in __format_entry_column_type
    formatted_name = source_name.replace('&', '_')
TypeError: a bytes-like object is required, not 'str'
```

**- How I did it**
- Simple check if column_type is a `bytes` object, then convert it to `str`.

Since on some MySQL installations the column type is stored and returned as a bytes object, we need to convert it to a str object. Right now using UTF-8 encoding for all if it's a `bytes` object. Since other RDBMS' don't seem to return like that, left a comment in the code, so we revisit that, in the scenario where we need to have different encodings for each RDBM connector.

**- How to verify it**
I was able to simulate this, installing the latest mysql version on a Mac OS using brew. So install that setup and run the connector with the schema:

```
CREATE SCHEMA DEMO;

CREATE TABLE IF NOT EXISTS DEMO.TASKS (
    task_id INT AUTO_INCREMENT PRIMARY KEY,
    task_sub_id INT NOT NULL,
    message VARCHAR(45),
    author VARCHAR(45),
    email VARCHAR(45),
    error VARCHAR(45),
    start_date DATE,
    due_date DATE,
    status TINYINT NOT NULL,
    priority TINYINT NOT NULL,
    description TEXT,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);
```

On the old version the error happens, with this change, the connector runs successfully:

==============Scrape metadata===============
INFO:root:Scrapping metadata from connection_args
INFO:root:
1 table containers ready to be ingested...
INFO:root:

==============Prepare metadata===============
INFO:root:
--> database: Demo
INFO:root:
1 tables ready to be ingested...
INFO:root:
==============Ingest metadata===============
...
INFO:root:
============End mysql-to-datacatalog============

**- Description for the changelog**
I will bump the RDBMS commons and MySQL connector versions in a subsequent PR.

Fixes #73