### PR TITLE
BUMP RDBMS commons version

### DIFF
--- a/google-datacatalog-rdbms-connector/setup.py
+++ b/google-datacatalog-rdbms-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-rdbms-connector',
-    version='0.12.1',
+    version='0.12.2',
     author='Google LLC',
     description=
     'Commons library for ingesting RDBMS metadata into Google Cloud Data Catalog',


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-rdbms/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Bump RDBMS commons version `0.12.1` -> `0.12.2` to publish to PyPI.

This version bump is to publish the fix #73 for MySQL,  the MySQL connector considers the following version of the RDBMS commons:
```
    install_requires=('mysql-connector-python',
                      'google-datacatalog-rdbms-connector>=0.12.0<0.13.0'),
```
So no need to also bump the MySQL connector version.
