### PR TITLE
add table_schema into LEFT JOIN to resolve duplicates when different …

### DIFF
--- a/google-datacatalog-postgresql-connector/README.md
+++ b/google-datacatalog-postgresql-connector/README.md
@@ -232,7 +232,7 @@ COPY (
     select t.table_schema as schema_name, t.table_name, t.table_type, c.column_name, c.column_default as column_default_value, c.is_nullable as column_nullable, c.data_type as column_type,
             c.character_maximum_length as column_char_length, c.numeric_precision as column_numeric_precision  
         from information_schema.tables t
-            join  information_schema.columns c on c.table_name = t.table_name
+            join  information_schema.columns c on c.table_name = t.table_name and c.table_schema = t.table_schema
         where t.table_schema not in ('pg_catalog', 'information_schema', 'pg_toast', 'gp_toolkit')
             and c.table_schema not in ('pg_catalog', 'information_schema', 'pg_toast', 'gp_toolkit')
     ) 


### PR DESCRIPTION
**- What I did**
Updated postgresql connector README

**- How I did it**
When I ran the suggest query from the doc (for csv integration), and as I have multiple tables with the same name on different schemas, the columns from different tables got mixed from other tables as the join only takes into account the table name, so I added schema as well to the join clause.

**- How to verify it**
Run the new query on a database that have different schemas that contains tables with the same name, it will return the expected schema for each table instead of the combination of the columns from different tables that match their name on different schemas

**- Description for the changelog**
<!--
Added table_schema on csv query for postgresql connector
-->

